### PR TITLE
add patch to make AmberTools v21 CMake files aware of FlexiBLAS + remove Python versionsuffix

### DIFF
--- a/easybuild/easyconfigs/a/AmberTools/AmberTools-21-foss-2021a.eb
+++ b/easybuild/easyconfigs/a/AmberTools/AmberTools-21-foss-2021a.eb
@@ -2,7 +2,6 @@ easyblock = 'EB_Amber'
 
 name = 'AmberTools'
 version = '21'
-versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://ambermd.org/'
 description = """AmberTools consists of several independently developed packages that work well by themselves,
@@ -13,20 +12,17 @@ toolchain = {'name': 'foss', 'version': '2021a'}
 toolchainopts = {'usempi': True}
 
 sources = [SOURCE_TAR_BZ2]
-
 patches = [
     'AmberTools-20_fix_missing_MPI_LIBRARY_error.patch',
     'AmberTools-20_cmake-locate-netcdf.patch',
+    'AmberTools-21_CMake-FlexiBLAS.patch',
 ]
-
-# Use included BLAS as FlexiBlas is not linked properly
-# configopts = " -DBLA_VENDOR=FlexiBLAS"
-configopts = " -DBLA_VENDOR=Generic"
-
 checksums = [
     'f55fa930598d5a8e9749e8a22d1f25cab7fcf911d98570e35365dd7f262aaafd',  # AmberTools-21.tar.bz2
-    '0b89a0624167bc23876bcdefcb1055f591e38e3bd559a71d5749e342bd311acc',  # AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
+    # AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
+    '0b89a0624167bc23876bcdefcb1055f591e38e3bd559a71d5749e342bd311acc',
     '473e07c53b6f641d96d333974a6af2e03413fecef79f879d3fdecf7fecaab4d0',  # AmberTools-20_cmake-locate-netcdf.patch
+    '9543812c24c4b7842f64f1f8abaf2c92b5c4c0fadcdbd9811e76b81a778f0d36',  # AmberTools-21_CMake-FlexiBLAS.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/a/AmberTools/AmberTools-21_CMake-FlexiBLAS.patch
+++ b/easybuild/easyconfigs/a/AmberTools/AmberTools-21_CMake-FlexiBLAS.patch
@@ -1,0 +1,91 @@
+make CMake scripts that picks BLAS/LAPACK library aware of FlexiBLAS
+author: Kenneth Hoste (HPC-UGent)
+--- cmake/patched-cmake-modules/FindBLASFixed.cmake.orig	2022-05-04 18:53:42.410384491 +0200
++++ cmake/patched-cmake-modules/FindBLASFixed.cmake	2022-05-04 18:54:39.034612008 +0200
+@@ -36,7 +36,7 @@
+ #   BLA_F95     if set on tries to find the f95 interfaces for BLAS/LAPACK
+ #
+ # ######### ## List of vendors (BLA_VENDOR) valid in this module #
+-# Goto,OpenBLAS,ATLAS PhiPACK,CXML,DXML,SunPerf,SCSL,SGIMATH,IBMESSL,
++# Goto,OpenBLAS,FlexiBLAS ATLAS PhiPACK,CXML,DXML,SunPerf,SCSL,SGIMATH,IBMESSL,
+ # ACML,ACML_MP,ACML_GPU,Apple, NAS, Generic
+ 
+ include(CMakePushCheckState)
+@@ -49,8 +49,8 @@
+ 	set(BLA_VENDOR_DEFAULT "All")
+ endif ()
+ 
+-set(BLA_VENDOR ${BLA_VENDOR_DEFAULT} CACHE STRING "BLAS vendor to use for BLAS and Lapack.  Valid values: All, Goto, OpenBLAS, ATLAS, PhiPACK, CXML, DXML, SunPerf, SCSL, SGIMATH, IBMESSL, ACML, ACML_MP, ACML_GPU, Apple, NAS, Generic")
+-validate_configuration_enum(BLA_VENDOR  All Goto OpenBLAS ATLAS PhiPACK CXML DXML SunPerf SCSL SGIMATH IBMESSL ACML ACML_MP ACML_GPU Apple NAS Generic)
++set(BLA_VENDOR ${BLA_VENDOR_DEFAULT} CACHE STRING "BLAS vendor to use for BLAS and Lapack.  Valid values: All, Goto, OpenBLAS, FlexiBLAS, ATLAS, PhiPACK, CXML, DXML, SunPerf, SCSL, SGIMATH, IBMESSL, ACML, ACML_MP, ACML_GPU, Apple, NAS, Generic")
++validate_configuration_enum(BLA_VENDOR  All Goto OpenBLAS FlexiBLAS ATLAS PhiPACK CXML DXML SunPerf SCSL SGIMATH IBMESSL ACML ACML_MP ACML_GPU Apple NAS Generic)
+ 
+ if(DEFINED BLAS_FIND_QUIETLY)
+ 	set(CMAKE_REQUIRED_QUIET ${BLAS_FIND_QUIETLY})
+@@ -159,6 +159,20 @@
+  endif()
+ endif ()
+ 
++if (BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All")
++ if(NOT BLAS_LIBRARIES)
++	 # FlexiBLAS (https://github.com/mpimd-csc/flexiblas)
++	check_fortran_libraries(
++	BLAS_LIBRARIES
++	BLAS
++	sgemm
++	""
++	"flexiblas"
++	""
++	)
++ endif()
++endif ()
++
+ if (BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+ 	# OpenBLAS (http://www.openblas.net)
+@@ -524,4 +538,4 @@
+ endif()
+ 
+ cmake_pop_check_state()
+-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_blas_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+\ No newline at end of file
++set(CMAKE_FIND_LIBRARY_SUFFIXES ${_blas_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+--- cmake/patched-cmake-modules/FindLAPACKFixed.cmake.orig	2022-05-04 18:56:14.315407989 +0200
++++ cmake/patched-cmake-modules/FindLAPACKFixed.cmake	2022-05-04 18:56:39.930772703 +0200
+@@ -36,7 +36,7 @@
+ #   BLA_F95     if set on tries to find the f95 interfaces for BLAS/LAPACK
+ #
+ # ## List of vendors (BLA_VENDOR) valid in this module:
+-# OpenBLAS, ACML,Apple, NAS, Generic
++# OpenBLAS, FlexiBLAS, ACML,Apple, NAS, Generic
+ 
+ set(_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+ 
+@@ -173,6 +173,20 @@
+ 		endif()
+ 	endif ()
+ 	
++	if(BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All")
++		if(NOT LAPACK_LIBRARIES)
++			check_lapack_libraries(
++			LAPACK_LIBRARIES
++			LAPACK
++			cheev
++			""
++			"flexiblas"
++			"${BLAS_LIBRARIES}"
++			""
++			)
++		endif()
++	endif()
++	
+ 	if(BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
+ 		if(NOT LAPACK_LIBRARIES)
+ 			check_lapack_libraries(
+@@ -289,4 +303,4 @@
+ endif()
+ 
+ cmake_pop_check_state()
+-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+\ No newline at end of file
++set(CMAKE_FIND_LIBRARY_SUFFIXES ${_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})


### PR DESCRIPTION
@fwautele The patch file along with the changes in https://github.com/easybuilders/easybuild-easyblocks/pull/2720 fix the failing sanity check that detects that AmberTools is being linked directly with OpenBLAS rather than with FlexiBLAS as it's supposed to with `foss/2021a`.

Merging this PR will update your PR https://github.com/easybuilders/easybuild-easyconfigs/pull/14386 accordingly, and should make it ready to merge (as soon as https://github.com/easybuilders/easybuild-easyblocks/pull/2720 is merged).

To test, you can use `eb --from-pr 14386 --include-easyblocks-from-pr 2720` (after merging this PR right here)